### PR TITLE
Point SEO and deploy at custom domain janeckimateusz.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_message: "Deploy Next.js app to Pages"
-          cname: '' # Add your custom domain here if you have one
+          cname: 'janeckimateusz.com'
           force_orphan: true
 
       - name: Create .nojekyll file

--- a/modern-portfolio/src/app/layout.tsx
+++ b/modern-portfolio/src/app/layout.tsx
@@ -2,7 +2,7 @@ import "./globals.css";
 import React from "react";
 import type { Metadata } from "next";
 
-const SITE_URL = "https://janeckigit.github.io";
+const SITE_URL = "https://janeckimateusz.com";
 const NAME = "Mateusz Janecki";
 const TITLE = "Mateusz Janecki — Scrum Master & IT";
 const DESCRIPTION =
@@ -21,6 +21,7 @@ export const metadata: Metadata = {
   publisher: NAME,
   keywords: [
     "Mateusz Janecki",
+    "Janecki Mateusz",
     "Scrum Master",
     "PSM I",
     "portfolio",
@@ -82,6 +83,7 @@ const jsonLd = {
   "@context": "https://schema.org",
   "@type": "Person",
   name: NAME,
+  alternateName: "Janecki Mateusz",
   url: SITE_URL,
   image: `${SITE_URL}/profile.jpg`,
   jobTitle: "Scrum Master",

--- a/modern-portfolio/src/app/robots.ts
+++ b/modern-portfolio/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const SITE_URL = "https://janeckigit.github.io";
+const SITE_URL = "https://janeckimateusz.com";
 
 export const dynamic = "force-static";
 

--- a/modern-portfolio/src/app/sitemap.ts
+++ b/modern-portfolio/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const SITE_URL = "https://janeckigit.github.io";
+const SITE_URL = "https://janeckimateusz.com";
 
 export const dynamic = "force-static";
 


### PR DESCRIPTION
- Persist CNAME in the Pages deploy workflow so the custom domain survives each deployment (it was being wiped by cname: '')
- Switch canonical URL, Open Graph, sitemap, robots and JSON-LD from janeckigit.github.io to janeckimateusz.com
- Add reversed-name alternateName ("Janecki Mateusz") to Person structured data and keywords


Claude-Session: https://claude.ai/code/session_01U5qkwt87HJdKE5bSasoN33