### PR TITLE
Use personal photo in the profile README

### DIFF
--- a/docs/github-profile/README.md
+++ b/docs/github-profile/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://avatars.githubusercontent.com/u/100022533?v=4" width="120" style="border-radius:50%" alt="Mateusz Janecki" />
+<img src="https://raw.githubusercontent.com/JaneckiGit/janeckigit.github.io/main/modern-portfolio/public/profile.jpg" width="220" alt="Mateusz Janecki" />
 
 # Hi, I'm Mateusz Janecki 👋
 


### PR DESCRIPTION
## Summary

- Replace the GitHub avatar in `docs/github-profile/README.md` with the personal photo already hosted in this repo (`modern-portfolio/public/profile.jpg`), referenced via its raw GitHub URL so it renders in the `JaneckiGit/JaneckiGit` profile README once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8BnqSin14ydU37bSoojYP

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8BnqSin14ydU37bSoojYP)_