### PR TITLE
Profile README: pull round GitHub avatar

### DIFF
--- a/docs/github-profile/README.md
+++ b/docs/github-profile/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/JaneckiGit/janeckigit.github.io/main/modern-portfolio/public/profile.jpg" width="220" alt="Mateusz Janecki" />
+<img src="https://images.weserv.nl/?url=github.com/JaneckiGit.png&w=440&h=440&fit=cover&mask=circle" width="220" alt="Mateusz Janecki" />
 
 # Hi, I'm Mateusz Janecki 👋
 


### PR DESCRIPTION
## Summary

- Replace the static photo in `docs/github-profile/README.md` with the user's live GitHub avatar (`github.com/JaneckiGit.png`) rendered as a circle via `images.weserv.nl` (`mask=circle`), so the profile README always shows the current round profile picture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8BnqSin14ydU37bSoojYP

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8BnqSin14ydU37bSoojYP)_